### PR TITLE
Remove default Nginx config and fix [emerg] bind() to 0.0.0.0:80 failed (13: permission denied)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN chown -R booktype:booktype /code/ \
 
 # copy configs
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+RUN rm /etc/nginx/sites-enabled/default
 COPY configs/nginx_booktype.conf /etc/nginx/sites-enabled/
 COPY configs/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY configs/uwsgi.ini /code/configs


### PR DESCRIPTION
@bmg1919 I know it's been a few months since you've worked on this, but are you still interested in working on Booktype? You've done a great job bringing Booktype into a modern Python 3 world, but when I run it and try to edit a book, it never loads with Javascript console errors: https://github.com/kekkoudesu/Booktype-py3/issues/1

Sorry, I couldn't find another way to contact you. Would you be interested in being contracted to fix up some (hopefully small) issues like this with Booktype so it can be deployed to a server?